### PR TITLE
Add tail bite mechanic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple cyber-themed Snake game built with Flutter. The game targets both mobil
 ## Features
 - Smoothly animated snake movement using `CustomPaint`.
 - Special frog item spawns every 10 seconds and grows the snake by five segments with a random color.
-- Self-collision trims the snake instead of ending the game.
+- Self-collision trims the snake instead of ending the game and deducts points equal to the bitten segments.
 - Wall collisions end the game.
 - Win when the snake reaches a length of 100 segments.
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -113,7 +113,11 @@ class _SnakeGamePageState extends State<SnakeGamePage>
 
     if (snake.contains(newHead)) {
       _audioPlayer.play(AssetSource('sounds/beep_low.wav'));
-      gameOver = true;
+      final collisionIndex = snake.indexOf(newHead);
+      snake.insert(0, newHead);
+      final bittenOff = snake.length - (collisionIndex + 1);
+      snake = snake.sublist(0, collisionIndex + 1);
+      currentScore = max(0, currentScore - bittenOff);
       return;
     }
 


### PR DESCRIPTION
## Summary
- implement tail bite logic so colliding with the snake's body cuts the tail and reduces the score
- document score loss after self-collision

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac4a57a088325a1774b8e6049bf87