### PR TITLE
Add Retro D-pad control for mobile

### DIFF
--- a/lib/direction.dart
+++ b/lib/direction.dart
@@ -1,0 +1,1 @@
+enum Direction { up, down, left, right }

--- a/lib/dpad.dart
+++ b/lib/dpad.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import 'direction.dart';
+
+class RetroDPad extends StatelessWidget {
+  final void Function(Direction) onDirection;
+
+  const RetroDPad({required this.onDirection, Key? key}) : super(key: key);
+
+  Widget _buildButton(IconData icon, Direction dir) {
+    return GestureDetector(
+      onTap: () => onDirection(dir),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.grey.shade800,
+          border: Border.all(color: Colors.white, width: 2),
+        ),
+        child: Icon(icon, color: Colors.white),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 150,
+      height: 150,
+      child: Stack(
+        children: [
+          Positioned(
+            top: 0,
+            left: 50,
+            right: 50,
+            height: 50,
+            child: _buildButton(Icons.arrow_drop_up, Direction.up),
+          ),
+          Positioned(
+            bottom: 0,
+            left: 50,
+            right: 50,
+            height: 50,
+            child: _buildButton(Icons.arrow_drop_down, Direction.down),
+          ),
+          Positioned(
+            left: 0,
+            top: 50,
+            bottom: 50,
+            width: 50,
+            child: _buildButton(Icons.arrow_left, Direction.left),
+          ),
+          Positioned(
+            right: 0,
+            top: 50,
+            bottom: 50,
+            width: 50,
+            child: _buildButton(Icons.arrow_right, Direction.right),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,10 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart';
 import 'package:audioplayers/audioplayers.dart';
+import 'dpad.dart';
+import 'direction.dart';
 
 void main() {
   runApp(const CyberSnakeApp());
@@ -59,6 +62,10 @@ class _SnakeGamePageState extends State<SnakeGamePage>
   bool paused = false;
   bool _directionChangedThisTick = false;
   DateTime _lastFrog = DateTime.now();
+  bool get _isMobile =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS);
 
   @override
   void initState() {
@@ -322,6 +329,18 @@ class _SnakeGamePageState extends State<SnakeGamePage>
                 color: Colors.indigoAccent,
               ),
             ),
+          if (_isMobile)
+            Positioned(
+              bottom: 16,
+              right: 16,
+              child: RetroDPad(
+                onDirection: (dir) {
+                  setState(() {
+                    _changeDirection(dir);
+                  });
+                },
+              ),
+            ),
         ],
       ),
     );
@@ -380,7 +399,6 @@ class _SnakePainter extends CustomPainter {
   bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
 }
 
-enum Direction { up, down, left, right }
 
 class _BlinkingText extends StatefulWidget {
   final String text;


### PR DESCRIPTION
## Summary
- add `RetroDPad` widget for directional input
- factor `Direction` enum into separate file
- show D-pad on iOS/Android devices only

## Testing
- `dart format --output=none lib/dpad.dart lib/main.dart lib/direction.dart` *(fails: `dart` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ace9b4688832591e644e0d00b956e